### PR TITLE
Test transformer + refactor

### DIFF
--- a/src/transformers/babel/__snapshots__/providerArgumentsTransformer.test.ts.snap
+++ b/src/transformers/babel/__snapshots__/providerArgumentsTransformer.test.ts.snap
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Provider Arguments Transformer Adds method name to provider arguments (@Provider() -> @Provider({name: "myProvidedDependency"}) 1`] = `
+"var _dec, _class;
+
+function _applyDecoratedDescriptor(target, property, decorators, descriptor, context) { var desc = {}; Object.keys(descriptor).forEach(function (key) { desc[key] = descriptor[key]; }); desc.enumerable = !!desc.enumerable; desc.configurable = !!desc.configurable; if ('value' in desc || desc.initializer) { desc.writable = true; } desc = decorators.slice().reverse().reduce(function (desc, decorator) { return decorator(target, property, desc) || desc; }, desc); if (context && desc.initializer !== void 0) { desc.value = desc.initializer ? desc.initializer.call(context) : void 0; desc.initializer = undefined; } if (desc.initializer === void 0) { Object.defineProperty(target, property, desc); desc = null; } return desc; }
+
+let MainGraph = (_dec = Provides({
+  name: \\"someString\\"
+}), (_class = class MainGraph {
+  someString({
+    stringProvider: stringProvider
+  }) {
+    return stringProvider.theString;
+  }
+
+}, (_applyDecoratedDescriptor(_class.prototype, \\"someString\\", [_dec], Object.getOwnPropertyDescriptor(_class.prototype, \\"someString\\"), _class.prototype)), _class));"
+`;
+
+exports[`Provider Arguments Transformer Does not add name if name is provided by the user 1`] = `
+"var _dec, _class;
+
+function _applyDecoratedDescriptor(target, property, decorators, descriptor, context) { var desc = {}; Object.keys(descriptor).forEach(function (key) { desc[key] = descriptor[key]; }); desc.enumerable = !!desc.enumerable; desc.configurable = !!desc.configurable; if ('value' in desc || desc.initializer) { desc.writable = true; } desc = decorators.slice().reverse().reduce(function (desc, decorator) { return decorator(target, property, desc) || desc; }, desc); if (context && desc.initializer !== void 0) { desc.value = desc.initializer ? desc.initializer.call(context) : void 0; desc.initializer = undefined; } if (desc.initializer === void 0) { Object.defineProperty(target, property, desc); desc = null; } return desc; }
+
+let MainGraph = (_dec = Provides({
+  name: 'myDependency'
+}), (_class = class MainGraph {
+  someString({
+    stringProvider: stringProvider
+  }) {
+    return stringProvider.theString;
+  }
+
+}, (_applyDecoratedDescriptor(_class.prototype, \\"someString\\", [_dec], Object.getOwnPropertyDescriptor(_class.prototype, \\"someString\\"), _class.prototype)), _class));"
+`;

--- a/src/transformers/babel/helpers/index.ts
+++ b/src/transformers/babel/helpers/index.ts
@@ -1,0 +1,60 @@
+/* eslint-disable no-param-reassign */
+import { types as t } from '@babel/core';
+import {
+  CallExpression,
+  ClassMethod,
+  Decorator,
+  Identifier,
+  ObjectExpression,
+  ObjectPattern,
+  ObjectProperty,
+} from '@babel/types';
+import { get } from 'lodash';
+
+export function providerIsNotNamed(decorator: Decorator): boolean {
+  const argument = getDecoratorArgument(decorator);
+  if (t.isObjectExpression(argument)) {
+    return argument.properties.find((p) => {
+      if (t.isObjectProperty(p)) {
+        return t.isIdentifier(p.key) && p.key.name === 'name';
+      }
+      return false;
+    }) === undefined;
+  }
+  return true;
+}
+
+export function addNameToProviderArguments(node: ClassMethod, decorator: Decorator) {
+  const argument = getDecoratorArgument(decorator) ?? t.objectExpression([]);
+  argument.properties.push(t.objectProperty(
+    t.identifier('name'),
+    t.stringLiteral(getMethodName(node)),
+  ));
+  (decorator.expression as CallExpression).arguments = [argument];
+}
+
+export function getDecoratorArgument(decorator: Decorator): ObjectExpression | undefined {
+  if (t.isCallExpression(decorator.expression)) {
+    return decorator.expression.arguments.find((a) => t.isObjectExpression(a)) as ObjectExpression;
+  }
+  return undefined;
+}
+
+export function getMethodName(node: ClassMethod): string {
+  if (t.isIdentifier(node.key)) return node.key.name;
+  throw new Error(`Tried to get class name but encountered unexpected key of type: ${node.key.type}`);
+}
+
+export function getProviderDecorator(decorators: Array<Decorator> | undefined | null): Decorator | undefined {
+  return decorators?.find((decorator) => get(decorator, 'expression.callee.name') === 'Provides');
+}
+
+export function getDecoratorName(decorator?: Decorator): string | undefined {
+  return get(decorator, 'expression.callee.name');
+}
+
+export function paramsToDestructuringAssignment(params: (Identifier | any)[]): ObjectPattern {
+  return t.objectPattern(params
+    .filter((p) => t.isIdentifier(p))
+    .map((p) => t.objectProperty(t.identifier(p.name), t.identifier(p.name))));
+}


### PR DESCRIPTION
The transformer now saves the mangled method name as an argument to the `@Provides` annotation. This also lets users write named providers themselves to avoid provider collision.

### Before
```ts
class MainGraph {
  @Provides()
  someString(stringProvider) {
    return stringProvider.theString;
  }
}
```

### After transforming
```ts
class MainGraph {
  @Provides({name: 'someString'})
  someString({stringProvider}) {
    return stringProvider.theString;
  }
}
```