### PR TITLE
Reenable constructor param injection tests

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,13 +1,13 @@
 module.exports = {
   presets: [
-    ['@babel/preset-env', { targets: { node: 'current' }, loose: true }],
+    ['@babel/preset-env', { targets: { node: 'current' }}],
     ['@babel/preset-typescript', {'onlyRemoveTypeImports': true}],
     '@babel/preset-react',
   ],
   plugins: [
     `${__dirname}/dist/transformers/babel-plugin-obsidian`,
     ['@babel/plugin-proposal-decorators', { legacy: true }],
-    ['@babel/plugin-proposal-class-properties', { loose: true }],
+    '@babel/plugin-proposal-class-properties',
     'babel-plugin-parameter-decorator'
   ],
 };

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@babel/preset-react": "7.16.x",
     "@babel/preset-typescript": "7.16.x",
     "@babel/types": "7.16.x",
+    "@babel/traverse": "7.16.x",
     "@johanblumenberg/ts-mockito": "1.x.x",
     "@testing-library/react": "^12.1.2",
     "@testing-library/react-hooks": "^7.0.2",

--- a/test/integration/classInjection.test.tsx
+++ b/test/integration/classInjection.test.tsx
@@ -8,53 +8,53 @@ describe('Class injection', () => {
     expect(uut.someString).toBe(injectedValues.fromStringProvider);
   });
 
-  // it('injects constructor arguments', () => {
-  //   const uut = new SingleArg();
-  //   expect(uut.anotherString).toBe(injectedValues.anotherString);
-  // });
+  it('injects constructor arguments', () => {
+    const uut = new SingleArg();
+    expect(uut.anotherString).toBe(injectedValues.anotherString);
+  });
 
-  // it('injects multiple constructor arguments', () => {
-  //   const uut = new MultiArg();
-  //   expect(uut.someString).toBe(injectedValues.fromStringProvider);
-  //   expect(uut.anotherString).toBe(injectedValues.anotherString);
-  // });
+  it('injects multiple constructor arguments', () => {
+    const uut = new MultiArg();
+    expect(uut.someString).toBe(injectedValues.fromStringProvider);
+    expect(uut.anotherString).toBe(injectedValues.anotherString);
+  });
 
-  // it('only injects if constructor arg is undefined', () => {
-  //   const uut = new MultiArg('override');
-  //   expect(uut.someString).toBe('override');
-  //   expect(uut.anotherString).toBe(injectedValues.anotherString);
-  // });
+  it('only injects if constructor arg is undefined', () => {
+    const uut = new MultiArg('override');
+    expect(uut.someString).toBe('override');
+    expect(uut.anotherString).toBe(injectedValues.anotherString);
+  });
 
-  // it('injects simple constructor args', () => {
-  //   const uut = new SimpleArgs();
-  //   expect(uut.someString).toBe(injectedValues.fromStringProvider);
-  //   expect(uut.anotherString).toBe(injectedValues.anotherString);
-  // });
+  it('injects simple constructor args', () => {
+    const uut = new SimpleArgs();
+    expect(uut.someString).toBe(injectedValues.fromStringProvider);
+    expect(uut.anotherString).toBe(injectedValues.anotherString);
+  });
 
   @Injectable(MainGraph)
   class SingleArg {
     @Inject() public readonly someString!: string;
 
-    // constructor(anotherString?: string);
-    // public constructor(@Inject() public anotherString: string) { }
+    constructor(anotherString?: string);
+    public constructor(@Inject() public anotherString: string) { }
   }
 
-  // @Injectable(MainGraph)
-  // class MultiArg {
-  //   constructor(anotherString?: string, someString?: string);
-  //   public constructor(
-  //     @Inject() public someString: string,
-  //     @Inject() public anotherString: string,
-  //   ) { }
-  // }
+  @Injectable(MainGraph)
+  class MultiArg {
+    constructor(anotherString?: string, someString?: string);
+    public constructor(
+      @Inject() public someString: string,
+      @Inject() public anotherString: string,
+    ) { }
+  }
 
-  // @Injectable(MainGraph)
-  // class SimpleArgs {
-  //   readonly someString: string;
+  @Injectable(MainGraph)
+  class SimpleArgs {
+    readonly someString: string;
 
-  //   constructor(anotherString?: string, someString?: string);
-  //   public constructor(@Inject() someString: string, @Inject() public anotherString: string) {
-  //     this.someString = someString;
-  //   }
-  // }
+    constructor(anotherString?: string, someString?: string);
+    public constructor(@Inject() someString: string, @Inject() public anotherString: string) {
+      this.someString = someString;
+    }
+  }
 });


### PR DESCRIPTION
* Remove the `loose` property from the babel plugins as apparently, it's [discouraged](https://2ality.com/2015/12/babel6-loose-mode.html).
* Add explicit dependency on `"@babel/traverse": "7.16.x"` since version 7.17.x broke `babel-plugin-parameter-decorator`