### PR TITLE
Support lazy injection from a specific graph instance

### DIFF
--- a/src/Obsidian.ts
+++ b/src/Obsidian.ts
@@ -12,8 +12,8 @@ export default class Obsidian {
     return graphRegistry.resolve(Graph, props) as unknown as ServiceLocator<T>;
   }
 
-  inject<T extends object>(target: T) {
-    return lazyInjector.inject(target);
+  inject<T extends object>(target: T, graph?: ObjectGraph) {
+    return lazyInjector.inject(target, graph);
   }
 
   addGraphMiddleware(middleware: GraphMiddleware) {

--- a/src/injectors/class/LazyInjector.ts
+++ b/src/injectors/class/LazyInjector.ts
@@ -1,12 +1,13 @@
+import { ObjectGraph } from '../../graph/ObjectGraph';
 import graphRegistry from '../../graph/registry/GraphRegistry';
 import InjectionMetadata from './InjectionMetadata';
 
 export const GRAPH_INSTANCE_NAME_KEY = 'GRAPH_INSTANCE_NAME';
 
 class LazyInjector<T extends object> {
-  inject(target: T): T {
+  inject(target: T, sourceGraph?: ObjectGraph): T {
     const injectionMetadata = new InjectionMetadata();
-    const graph = this.getGraphInstance(target);
+    const graph = sourceGraph ?? this.getGraphInstance(target);
     injectionMetadata.getLazyPropertiesToInject(target.constructor).forEach((key) => {
       Reflect.set(target, key, graph.retrieve(key));
     });

--- a/test/integration/lazyInject.test.tsx
+++ b/test/integration/lazyInject.test.tsx
@@ -25,6 +25,17 @@ describe('Class lazy injection', () => {
     const uut = new LazyPropertyConstructorInjection();
     expect(uut.constructor.name).toBe(LazyPropertyConstructorInjection.name);
   });
+
+  it('@LazyInjects from source graph', () => {
+    const obj = new LazyProperty();
+    const graph = new class extends MainGraph {
+      override someString(): string {
+        return 'overridden';
+      }
+    }();
+    Obsidian.inject(obj, graph);
+    expect(obj.someString).toBe('overridden');
+  });
 });
 
 @Injectable(MainGraph)


### PR DESCRIPTION
## API
```typescript
import {Obsidian, testKit} from 'react-obsidian';

@LazyInject() var someDep: SomeDep;

const graph = new MyGraph();
testKit.mockGraphs({ApplicationGraph: () => graph});
const uut = new MyClass(this, graph);

// someDep is resolved
```

Fixes #48 