### PR TITLE
Extract graph cleanup function to a dedicated file

### DIFF
--- a/jest.setup-after-env.js
+++ b/jest.setup-after-env.js
@@ -1,1 +1,4 @@
 require('setimmediate');
+require('reflect-metadata');
+require('./resetGraphs');
+

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,1 +1,0 @@
-import 'reflect-metadata';

--- a/resetGraphs.ts
+++ b/resetGraphs.ts
@@ -1,0 +1,5 @@
+import { Obsidian } from './src';
+
+beforeEach(() => {
+  Obsidian.resetGraphs();
+});

--- a/src/Obsidian.ts
+++ b/src/Obsidian.ts
@@ -23,4 +23,9 @@ export default class Obsidian {
   clearGraphMiddlewares() {
     graphRegistry.clearGraphMiddlewares();
   }
+
+  resetGraphs() {
+    graphRegistry.clearGraphMiddlewares();
+    graphRegistry.reset();
+  }
 }

--- a/testkit/index.ts
+++ b/testkit/index.ts
@@ -4,11 +4,6 @@ import { GraphMiddleware } from '../src/graph/registry/GraphMiddleware';
 import { Constructable } from '../src/types';
 import graphRegistry from '../src/graph/registry/GraphRegistry';
 
-beforeEach(() => {
-  graphRegistry.clearGraphMiddlewares();
-  graphRegistry.reset();
-});
-
 class TestKit {
   public mockGraphs(graphNameToGraph: Record<string, Constructable<ObjectGraph> | ((props: any) => ObjectGraph)>) {
     const graphMiddleware = new class extends GraphMiddleware {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2,7 +2,8 @@
   "include": [
     "src/**/*",
     "transformers/**/*",
-    "test/**/*"
+    "test/**/*",
+    "./resetGraphs.ts"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
Until now, we cleaned up graphs in a beforeEach hook registered when TestKit was required. TestKit is required by our index.ts - this means we always registered a beforeEach hook.

This commit extracts the beforeEach to a dedicated class. Users who want to cleanup automatically will need to require it from their jest.setup.ts file.