### PR TITLE
Fix lazy injection from concrete graphs

### DIFF
--- a/src/graph/registry/GraphRegistry.ts
+++ b/src/graph/registry/GraphRegistry.ts
@@ -14,6 +14,11 @@ export class GraphRegistry {
     this.graphToSubgraphs.set(constructor, new Set(subgraphs));
   }
 
+  ensureRegistered(graph: Graph) {
+    if (this.instanceToConstructor.get(graph)) return;
+    this.set(graph.constructor as any, graph);
+  }
+
   getSubgraphs(graph: Graph): Graph[] {
     const Graph = this.instanceToConstructor.get(graph)!;
     const subgraphs = this.graphToSubgraphs.get(Graph) ?? new Set();

--- a/src/injectors/class/LazyInjector.ts
+++ b/src/injectors/class/LazyInjector.ts
@@ -6,6 +6,7 @@ export const GRAPH_INSTANCE_NAME_KEY = 'GRAPH_INSTANCE_NAME';
 
 class LazyInjector<T extends object> {
   inject(target: T, sourceGraph?: ObjectGraph): T {
+    if (sourceGraph) graphRegistry.ensureRegistered(sourceGraph);
     const injectionMetadata = new InjectionMetadata();
     const graph = sourceGraph ?? this.getGraphInstance(target);
     injectionMetadata.getLazyPropertiesToInject(target.constructor).forEach((key) => {

--- a/test/acceptance/lazyInject.test.ts
+++ b/test/acceptance/lazyInject.test.ts
@@ -1,0 +1,56 @@
+import {
+  Graph,
+  LazyInject,
+  ObjectGraph,
+  Obsidian,
+  Provides,
+  testKit,
+} from '../../src';
+
+describe('Lazy inject', () => {
+  it('injects from a concrete graph instance', () => {
+    testKit.mockGraphs({ Subgraph: MockedSubgraph });
+
+    class Injected {
+      @LazyInject() graphString!: string;
+
+      constructor() {
+        Obsidian.inject(this, new MockedMainGraph());
+      }
+    }
+
+    expect(new Injected().graphString).toBe('from mocked main from mocked subgraph');
+  });
+});
+
+@Graph()
+class Subgraph extends ObjectGraph {
+  @Provides()
+  subgraphString(): string {
+    return 'from subgraph';
+  }
+}
+
+@Graph({ subgraphs: [Subgraph] })
+class MainGraph extends ObjectGraph {
+  @Provides()
+  graphString(subgraphString: string): string {
+    return `from main ${subgraphString}`;
+  }
+}
+
+@Graph()
+class MockedSubgraph extends Subgraph {
+  @Provides()
+  override subgraphString(): string {
+    return 'from mocked subgraph';
+  }
+}
+
+@Graph({ subgraphs: [MockedSubgraph] })
+class MockedMainGraph extends MainGraph {
+  @Provides()
+  override graphString(subgraphString: string): string {
+    return `from mocked main ${subgraphString}`;
+  }
+}


### PR DESCRIPTION
When injecting from a concrete graph, we don't resolve the graph from its class. This caused a bug where subgraphs were not mapped to the concrete graph since graph instances are registered when resolved.

This commit fixes the issue by ensuring the concrete graph is registered before injecting from it.