### PR TITLE
Fix @Singleton graphs being cleared according to ref count

### DIFF
--- a/src/graph/registry/GraphRegistry.test.ts
+++ b/src/graph/registry/GraphRegistry.test.ts
@@ -26,4 +26,11 @@ describe('GraphRegistry', () => {
     const afterReset = uut.resolve(SingletonGraph);
     expect(beforeReset).not.toEqual(afterReset);
   });
+
+  it(`clear() doesn't clear @Singleton graphs`, () => {
+    uut.register(SingletonGraph);
+    const graph = uut.resolve(SingletonGraph);
+    uut.clear(graph);
+    expect(uut.resolve(SingletonGraph)).toEqual(graph);
+  });
 });

--- a/src/graph/registry/GraphRegistry.ts
+++ b/src/graph/registry/GraphRegistry.ts
@@ -60,6 +60,7 @@ export class GraphRegistry {
 
   clear(graph: Graph) {
     const Graph = this.instanceToConstructor.get(graph)!;
+    if (this.isSingleton(Graph)) return;
     this.instanceToConstructor.delete(graph);
     this.constructorToInstance.get(Graph)!.delete(graph);
     this.nameToInstance.delete(graph.name);


### PR DESCRIPTION
Graphs marked as singletons should not be cleared by ref count maintained by lifecycle-aware React constructs like hooks and components.