### PR TITLE
Fix injection of memoized components

### DIFF
--- a/src/injectors/components/ComponentInjector.test.tsx
+++ b/src/injectors/components/ComponentInjector.test.tsx
@@ -8,12 +8,30 @@ describe('ComponentInjector', () => {
     count: number;
   }
 
-  const component = ({ count, someString }: OwnProps & Dependencies) => {
+  const Component = ({ count, someString }: OwnProps & Dependencies) => {
     return (<>{`${count} - ${someString}`}</>);
   };
 
   it('Rerenders on props change', () => {
-    const InjectedComponent = injectComponent(component, MainGraph);
+    const InjectedComponent = injectComponent(Component, MainGraph);
+    const { container, rerender } = render(<InjectedComponent count={0}/>);
+    expect(container.textContent).toBe('0 - Fear kills progress');
+
+    rerender(<InjectedComponent count={1}/>);
+    expect(container.textContent).toBe('1 - Fear kills progress');
+  });
+
+  it('Injects memoized component', () => {
+    const MemoizedComponent = React.memo(Component);
+    const InjectedComponent = injectComponent(MemoizedComponent, MainGraph);
+    const { container } = render(<InjectedComponent count={0}/>);
+
+    expect(container.textContent).toBe('0 - Fear kills progress');
+  });
+
+  it('Rerenders memoized components on props change', () => {
+    const MemoizedComponent = React.memo(Component);
+    const InjectedComponent = injectComponent(MemoizedComponent, MainGraph);
     const { container, rerender } = render(<InjectedComponent count={0}/>);
     expect(container.textContent).toBe('0 - Fear kills progress');
 

--- a/src/injectors/components/ComponentInjector.tsx
+++ b/src/injectors/components/ComponentInjector.tsx
@@ -4,6 +4,7 @@ import { ObjectGraph } from '../../graph/ObjectGraph';
 import PropsInjector from './PropsInjector';
 import useGraph from './useGraph';
 import { Constructable } from '../../types';
+import { isMemoizedComponent } from '../../utils/React';
 
 export default class ComponentInjector {
   inject<P>(
@@ -16,7 +17,7 @@ export default class ComponentInjector {
   }
 
   private wrapComponent<P>(
-    Target: React.FunctionComponent<P>,
+    InjectionCandidate: React.FunctionComponent<P>,
     Graph: Constructable<ObjectGraph>,
   ): React.FunctionComponent<Partial<P>> {
     return (passedProps: Partial<P>) => {
@@ -27,6 +28,7 @@ export default class ComponentInjector {
         setProxiedProps(new PropsInjector(graph).inject(passedProps));
       }, [passedProps]);
 
+      const Target = isMemoizedComponent(InjectionCandidate) ? InjectionCandidate.type : InjectionCandidate;
       return <>{Target(proxiedProps as unknown as P)}</>;
     };
   }

--- a/src/utils/React.ts
+++ b/src/utils/React.ts
@@ -1,0 +1,6 @@
+import { FunctionComponent } from 'react';
+
+type MemoizedComponent = React.MemoExoticComponent<FunctionComponent<any>>;
+export function isMemoizedComponent(component: FunctionComponent<any>): component is MemoizedComponent {
+  return (component as MemoizedComponent).type !== undefined;
+}


### PR DESCRIPTION
The issue happens because Obsidian invokes components as functions which is frowned upon. We should be using React.createElement, but we can't because it seems like it spreads props which break our proxied props useless.
This PR attempts to check if a component is memoized, and renders the concrete component.

Fixes #60