### PR TITLE
Fix extra render when component is first mounted

### DIFF
--- a/src/injectors/components/ComponentInjector.test.tsx
+++ b/src/injectors/components/ComponentInjector.test.tsx
@@ -60,7 +60,7 @@ describe('ComponentInjector', () => {
     return (<>{`${renderCount.current} - ${someString}`}</>);
   };
 
-  it('xxx', () => {
+  it('Renders once when component is created', () => {
     const MemoizedComponent = React.memo<any>(RenderCounter);
     const InjectedComponent = injectComponent(MemoizedComponent, MainGraph);
     const { container } = render(<InjectedComponent />);

--- a/src/injectors/components/ComponentInjector.test.tsx
+++ b/src/injectors/components/ComponentInjector.test.tsx
@@ -1,5 +1,5 @@
 import { render } from '@testing-library/react';
-import React from 'react';
+import React, { useRef } from 'react';
 import MainGraph, { Dependencies } from '../../../test/fixtures/MainGraph';
 import { injectComponent } from './InjectComponent';
 
@@ -52,5 +52,18 @@ describe('ComponentInjector', () => {
     arePropsEqual = false;
     rerender(<InjectedComponent count={2} />);
     expect(container.textContent).toBe('2 - Fear kills progress');
+  });
+
+  const RenderCounter = ({ someString }: OwnProps & Dependencies) => {
+    const renderCount = useRef(0);
+    renderCount.current += 1;
+    return (<>{`${renderCount.current} - ${someString}`}</>);
+  };
+
+  it('xxx', () => {
+    const MemoizedComponent = React.memo<any>(RenderCounter);
+    const InjectedComponent = injectComponent(MemoizedComponent, MainGraph);
+    const { container } = render(<InjectedComponent />);
+    expect(container.textContent).toBe('1 - Fear kills progress');
   });
 });

--- a/src/injectors/components/ComponentInjector.tsx
+++ b/src/injectors/components/ComponentInjector.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import { ObjectGraph } from '../../graph/ObjectGraph';
 import PropsInjector from './PropsInjector';
@@ -22,17 +22,8 @@ export default class ComponentInjector {
   ): React.FunctionComponent<Partial<P>> {
     return (passedProps: Partial<P>) => {
       const graph = useGraph(Graph, passedProps);
-      const [proxiedProps, setProxiedProps] = useState(new PropsInjector(graph).inject(passedProps));
-
-      useEffect(() => {
-        if (isMemoizedComponent(InjectionCandidate) && InjectionCandidate.compare) {
-          if (!InjectionCandidate.compare(proxiedProps, passedProps)) {
-            setProxiedProps(new PropsInjector(graph).inject(passedProps));
-          }
-        } else {
-          setProxiedProps(new PropsInjector(graph).inject(passedProps));
-        }
-      }, [passedProps]);
+      // const [proxiedProps, setProxiedProps] = useState(new PropsInjector(graph).inject(passedProps));
+      const proxiedProps = new PropsInjector(graph).inject(passedProps);
 
       const Target = isMemoizedComponent(InjectionCandidate) ? InjectionCandidate.type : InjectionCandidate;
       return <>{Target(proxiedProps as unknown as P)}</>;

--- a/src/utils/React.ts
+++ b/src/utils/React.ts
@@ -11,5 +11,5 @@ export function genericMemo<C extends React.ComponentType<any>>(
   Component: Parameters<typeof React.memo>[0],
   propsAreEqual?: Parameters<typeof React.memo>[1],
 ) {
-  return (React.memo(Component, propsAreEqual) as unknown) as C;
+  return React.memo(Component, propsAreEqual) as unknown as C;
 }

--- a/src/utils/React.ts
+++ b/src/utils/React.ts
@@ -1,8 +1,15 @@
-import { FunctionComponent } from 'react';
+import React, { FunctionComponent } from 'react';
 
 type MemoizedComponent = React.MemoExoticComponent<FunctionComponent<any>> & {
   compare?: (prevProps: any, nextProps: any) => boolean;
 };
 export function isMemoizedComponent(component: FunctionComponent<any>): component is MemoizedComponent {
   return (component as MemoizedComponent).type !== undefined;
+}
+
+export function genericMemo<C extends React.ComponentType<any>>(
+  Component: Parameters<typeof React.memo>[0],
+  propsAreEqual?: Parameters<typeof React.memo>[1],
+) {
+  return (React.memo(Component, propsAreEqual) as unknown) as C;
 }


### PR DESCRIPTION
Components wrapped with `injectComponent` were rendered twice on mount due to incorrect use of useEffect hook.