### PR TITLE
chore: expand vscode extension publishing docs

### DIFF
--- a/packages/vscode-language-server-obsidian/docs.md
+++ b/packages/vscode-language-server-obsidian/docs.md
@@ -13,11 +13,26 @@ Run `npm run test` to execute all test from the terminal. Alternatively, install
 4. Set break points by clicking in the gutter to the left of the code
 
 ## Publishing
-First, make sure you have the VSCode Extension Manager (vsce) installed globally.
+First, make sure you have the VSCode Extension Manager (vsce) and the OpenVSX publisher (ovsx) installed globally.
 ```shell
-npm install -g @vscode/vsce
+npm install -g @vscode/vsce ovsx
 ```
 
-Use `vsce` to package and publish the extension. Run `vsce package --no-dependencies` to generate a `.vsix` file which can be installed in VSCode by running `code --install-extension <path-to-vsix-file>`. To install on Cursor, run `cursor --install-extension <path-to-vsix-file>`.
+### Packaging
+Run `vsce package --no-dependencies` to generate a `.vsix` file which can be installed in VSCode by running `code --install-extension <path-to-vsix-file>`. To install on Cursor, run `cursor --install-extension <path-to-vsix-file>`.
 
 Note: The `--no-dependencies` flag is required because this is a Yarn workspace monorepo. The extension bundles all required code via esbuild, so no separate dependency packaging is needed.
+
+### VSCode Marketplace
+Requires a Personal Access Token (PAT) from [Azure DevOps](https://dev.azure.com) with the **Marketplace > Manage** scope.
+```shell
+vsce publish --no-dependencies -p <pat>
+```
+Alternatively, upload the `.vsix` file manually via the [publisher management page](https://marketplace.visualstudio.com/manage).
+
+### OpenVSX
+Requires an access token from [open-vsx.org](https://open-vsx.org).
+```shell
+ovsx publish <path-to-vsix> -p <token>
+```
+Alternatively, upload the `.vsix` file manually via the [extension page on open-vsx.org](https://open-vsx.org).

--- a/packages/vscode-language-server-obsidian/package.json
+++ b/packages/vscode-language-server-obsidian/package.json
@@ -4,7 +4,7 @@
   "description": "Intellisense support for Obsidian dependency injection framework",
   "publisher": "guycarmeli",
   "icon": "obsidian.png",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "license": "ISC",
   "main": "./client/dist/extension.js",
   "scripts": {


### PR DESCRIPTION
Expand the publishing section in the vscode-language-server-obsidian docs.

- Split into Packaging, VSCode Marketplace, and OpenVSX subsections
- Add CLI publish commands for both marketplaces
- Add links to web upload pages for both marketplaces