### PR TITLE
chore: release 2.31.0

### DIFF
--- a/packages/eslint-plugin-obsidian/package.json
+++ b/packages/eslint-plugin-obsidian/package.json
@@ -2,7 +2,7 @@
   "name": "eslint-plugin-obsidian",
   "description": "ESLint rules for Obsidian",
   "main": "dist/index.js",
-  "version": "2.31.0-alpha.8",
+  "version": "2.31.0",
   "scripts": {
     "build": "npx tsc --project tsconfig.prod.json",
     "test": "npx jest --colors",
@@ -25,7 +25,7 @@
   "dependencies": {
     "lodash": "^4.17.21",
     "ts-morph": "^25.0.1",
-    "ts-morph-extensions": "^2.31.0-alpha.8"
+    "ts-morph-extensions": "^2.31.0"
   },
   "devDependencies": {
     "@babel/core": "7.26.10",

--- a/packages/react-obsidian/package.json
+++ b/packages/react-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-obsidian",
-  "version": "2.31.0-alpha.8",
+  "version": "2.31.0",
   "description": "Dependency injection framework for React and React Native applications",
   "scripts": {
     "prepack": "yarn lint && tsc --project tsconfig.prod.json",

--- a/packages/swc-plugin-obsidian/Cargo.toml
+++ b/packages/swc-plugin-obsidian/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swc_plugin_obsidian"
-version = "2.31.0-alpha.8"
+version = "2.31.0"
 edition = "2021"
 
 [lib]

--- a/packages/swc-plugin-obsidian/package.json
+++ b/packages/swc-plugin-obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swc-plugin-obsidian",
-  "version": "2.31.0-alpha.8",
+  "version": "2.31.0",
   "description": "SWC plugin for Obsidian to be used with Vite or NextJS",
   "author": "Guy Carmeli",
   "main": "src/index.js",

--- a/packages/ts-morph-extensions/package.json
+++ b/packages/ts-morph-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-morph-extensions",
-  "version": "2.31.0-alpha.8",
+  "version": "2.31.0",
   "description": "Extensions and utilities for working with ts-morph projects and TypeScript configurations",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10756,7 +10756,7 @@ __metadata:
     lodash: "npm:^4.17.21"
     react-obsidian: "workspace:*"
     ts-morph: "npm:^25.0.1"
-    ts-morph-extensions: "npm:^2.31.0-alpha.8"
+    ts-morph-extensions: "npm:^2.31.0"
     typescript: "npm:^5.8.0"
   peerDependencies:
     "@typescript-eslint/parser": ">=7.0.0"
@@ -19620,7 +19620,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-morph-extensions@npm:^2.31.0-alpha.8, ts-morph-extensions@workspace:packages/ts-morph-extensions":
+"ts-morph-extensions@npm:^2.31.0, ts-morph-extensions@workspace:packages/ts-morph-extensions":
   version: 0.0.0-use.local
   resolution: "ts-morph-extensions@workspace:packages/ts-morph-extensions"
   dependencies:


### PR DESCRIPTION
Bumps all packages from `2.31.0-alpha.8` to `2.31.0` stable release.

- `react-obsidian`: 2.31.0-alpha.8 → 2.31.0
- `eslint-plugin-obsidian`: 2.31.0-alpha.8 → 2.31.0
- `swc-plugin-obsidian`: 2.31.0-alpha.8 → 2.31.0
- `ts-morph-extensions`: 2.31.0-alpha.8 → 2.31.0