### PR TITLE
Fix graph registry retaining reset module constructors

### DIFF
--- a/packages/react-obsidian/src/graph/registry/GraphRegistry.test.ts
+++ b/packages/react-obsidian/src/graph/registry/GraphRegistry.test.ts
@@ -76,6 +76,20 @@ describe('GraphRegistry', () => {
     expect(() => uut.resolve('main')).toThrow();
   });
 
+  it('keeps graph registration metadata weakly', () => {
+    expect((uut as any).graphToSubgraphs).toBeInstanceOf(WeakMap);
+    expect((uut as any).graphToPrivateSubgraphs).toBeInstanceOf(WeakMap);
+  });
+
+  it('clears graph cleanup listeners on reset', () => {
+    const graph = uut.resolve(MainGraph);
+    (uut as any).registerOnClearListener(graph, jest.fn());
+
+    uut.clearAll();
+
+    expect((uut as any).onClearListeners.size).toBe(0);
+  });
+
   it('clears graph generator for a specific graph', () => {
     uut.registerGraphGenerator('main', () => MainGraph);
     const graph = uut.resolve('main');

--- a/packages/react-obsidian/src/graph/registry/GraphRegistry.ts
+++ b/packages/react-obsidian/src/graph/registry/GraphRegistry.ts
@@ -14,8 +14,8 @@ export class GraphRegistry {
   private readonly injectionTokenToInstance = new Map<string, Graph>();
   private readonly instanceToInjectionToken = new Map<Graph, string>();
   private readonly nameToInstance = new Map<string, Graph>();
-  private readonly graphToSubgraphs = new Map<Constructable<Graph>, Set<Constructable<Graph>>>();
-  private readonly graphToPrivateSubgraphs = new Map<Constructable<Graph>, Set<Constructable<Graph>>>();
+  private readonly graphToSubgraphs = new WeakMap<Constructable<Graph>, Set<Constructable<Graph>>>();
+  private readonly graphToPrivateSubgraphs = new WeakMap<Constructable<Graph>, Set<Constructable<Graph>>>();
   private readonly graphMiddlewares = new GraphMiddlewareChain();
   private readonly keyToGenerator = new Map<string,() => Constructable<Graph>>();
   private readonly keyToGraph = new Map<string, Constructable<Graph>>();
@@ -277,6 +277,7 @@ export class GraphRegistry {
     this.instanceToInjectionToken.clear();
     this.keyToGenerator.clear();
     this.keyToGraph.clear();
+    this.onClearListeners.clear();
   }
 }
 


### PR DESCRIPTION
## Summary
- Store graph registration metadata in WeakMaps so reset module constructor identities are not retained by the global registry
- Clear pending graph cleanup listeners when the registry is reset
- Add regression coverage for weak graph metadata and listener cleanup

## Context
Headless Jest runs with `resetModules: true` can re-evaluate decorated graph modules on every test. The global graph registry kept `@Graph` constructor metadata in strong Maps, which retained old constructor identities and their module contexts after `Obsidian.clearGraphs()`.

## Testing
- `git diff --check`
- Unable to run Jest locally: fresh clone install fails during Yarn fetch with repeated `RequestError: read ENOTCONN`.
